### PR TITLE
Add type="text" to input

### DIFF
--- a/lib/cpr-mask.component.js
+++ b/lib/cpr-mask.component.js
@@ -4,7 +4,7 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 var _react = require('react');
 
@@ -24,7 +24,7 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-var InputControl = (function (_React$Component) {
+var InputControl = function (_React$Component) {
   _inherits(InputControl, _React$Component);
 
   function InputControl(props) {
@@ -103,6 +103,7 @@ var InputControl = (function (_React$Component) {
             this.props.sideChars.left
           ) : null,
           _react2.default.createElement('input', {
+            type: 'text',
             ref: function ref(inputRef) {
               return _this2.input = inputRef;
             },
@@ -164,7 +165,7 @@ var InputControl = (function (_React$Component) {
   }]);
 
   return InputControl;
-})(_react2.default.Component);
+}(_react2.default.Component);
 
 InputControl.defaultProps = {
   filler: " ",
@@ -216,8 +217,8 @@ InputControl.propTypes = {
   validateMethod: _react.PropTypes.func,
   //Function that can transform the value before passing it up
   decoder: _react.PropTypes.func,
+  //Function that changes value as it comes into cpr-mask
   //Encoder should probably be used if you're using a decoder
-	//Changes value as it comes into cpr-mask
   encoder: _react.PropTypes.func
 };
 exports.default = InputControl;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cpr-mask",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A masking component for react",
   "main": "lib/cpr-mask.component.js",
   "scripts": {

--- a/src/cpr-mask.component.js
+++ b/src/cpr-mask.component.js
@@ -67,6 +67,7 @@ export default class InputControl extends React.Component {
             ? <span>{this.props.sideChars.left}</span>
             : null}
           <input
+	        type="text"
             ref={(inputRef) => this.input = inputRef}
             value={this.props.masks.length ? this.state.maskValue : this.state.value}
             onChange={this.handleChange.bind(this)}
@@ -127,7 +128,7 @@ export default class InputControl extends React.Component {
 		sideChars: {},
 		encoder: value => value,
 		decoder: value => value,
-  }
+  };
   static propTypes = {
     //name given to the surrounding div
     className: PropTypes.string,
@@ -161,5 +162,5 @@ export default class InputControl extends React.Component {
 		//Function that changes value as it comes into cpr-mask
 		//Encoder should probably be used if you're using a decoder
 		encoder: PropTypes.func,
-  }
+  };
 }


### PR DESCRIPTION
This is for styling stuff (specifically, the placeholder text color, which in canopy-styleguide is only applied to `input[type="text"]`)
